### PR TITLE
Fix inconsistent anticipation key behaviour

### DIFF
--- a/nrclex.py
+++ b/nrclex.py
@@ -23,7 +23,7 @@ def build_word_affect(self):
     for word in affect_list:
         affect_frequencies[word] += 1
     sum_values = sum(affect_frequencies.values())
-    affect_percent = {'fear': 0.0, 'anger': 0.0, 'anticip': 0.0, 'trust': 0.0, 'surprise': 0.0, 'positive': 0.0,
+    affect_percent = {'fear': 0.0, 'anger': 0.0, 'anticipation': 0.0, 'trust': 0.0, 'surprise': 0.0, 'positive': 0.0,
                       'negative': 0.0, 'sadness': 0.0, 'disgust': 0.0, 'joy': 0.0}
     for key in affect_frequencies.keys():
         affect_percent.update({key: float(affect_frequencies[key]) / float(sum_values)})


### PR DESCRIPTION
Fixes #2 

The key `anticipation` does not appear when no word related to that emotion is used. It seems to be related to how the keys of the frequencies are handled: 

First, the `anticip` key is always present, since it is in the `affect_percent` dict. But it is never used.
https://github.com/metalcorebear/NRCLex/blob/5d66076ad897a2c9406d6c2a3b3d7b7cb3b25644/nrclex.py#L26  

The `anticipation` key is added instead through the frequencies collection.

The key is added here:
https://github.com/metalcorebear/NRCLex/blob/5d66076ad897a2c9406d6c2a3b3d7b7cb3b25644/nrclex.py#L23-L24

And it is added to the `affect_frequencies` here
https://github.com/metalcorebear/NRCLex/blob/5d66076ad897a2c9406d6c2a3b3d7b7cb3b25644/nrclex.py#L28-L29

Replacing the `anticip` key by `anticipation` should fix it.