### PR TITLE
Whole new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ Emotional affects measured include the following:
 * joy
 
 ## Sample Usage
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/metalcorebear/NRCLex/example.ipynb)
 
 `from nrclex import NRCLex`<br><br>
 
 
 *#Instantiate NRCLex object, you can pass your own dictionary filename in json format.*<br>
 
-`text_object = NRCLex(lexicon_file='nrc_en.json')`<br><br>
+`text_object = NRCLex(txt_file='Spanish-NRC-EmoLex.txt')`<br><br>
 
 
 *#You can pass your raw text to this method(for best results, 'text' should be unicode).*<br>

--- a/example.ipynb
+++ b/example.ipynb
@@ -1,0 +1,125 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Prepare dependencies and files\n",
+        "\n",
+        "Lexicon source is (C) 2016 National Research Council Canada (NRC) and this package is **for research purposes only**. Source: http://saifmohammad.com/WebPages/NRC-Emotion-Lexicon.htm As per the terms of use of the NRC Emotion Lexicon, if you use the lexicon or any derivative from it, cite this paper: Crowdsourcing a Word-Emotion Association Lexicon, Saif Mohammad and Peter Turney, Computational Intelligence, 29 (3), 436-465, 2013."
+      ],
+      "metadata": {
+        "id": "0cMm__BlMaid"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aGocXvXH68jN"
+      },
+      "outputs": [],
+      "source": [
+        "!pip -q install 'https://codeload.github.com/rivanfebrian123/NRCLex/zip/refs/heads/master'\n",
+        "!curl -so 'nrc.zip' 'http://saifmohammad.com/WebDocs/Lexicons/NRC-Emotion-Lexicon.zip'\n",
+        "!unzip -qn 'nrc.zip'\n",
+        "\n",
+        "import nltk\n",
+        "nltk.download('punkt')\n",
+        "nltk.download('omw-1.4')\n",
+        "nltk.download('wordnet')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Let's go!\n",
+        "\n",
+        "You can also try some other txt files, for example: `Spanish-NRC-EmoLex.txt`"
+      ],
+      "metadata": {
+        "id": "knsMsT0OMvJ9"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from nrclex import NRCLex\n",
+        "\n",
+        "pos = 0\n",
+        "neg = 0\n",
+        "text = \"she's always arguing!\"\n",
+        "\n",
+        "nrc = NRCLex('NRC-Emotion-Lexicon/NRC-Emotion-Lexicon-Wordlevel-v0.92.txt')\n",
+        "emotions = nrc.load_raw_text(text).affect_frequencies\n",
+        "\n",
+        "emotions"
+      ],
+      "metadata": {
+        "id": "8j01RB23Mj4I"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Messing around with sentiments"
+      ],
+      "metadata": {
+        "id": "quNcWFJwOFWT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pos += emotions['positive']\n",
+        "pos += emotions['joy']\n",
+        "pos += emotions['trust']\n",
+        "pos += emotions['anticipation']\n",
+        "\n",
+        "neg += emotions['negative']\n",
+        "neg += emotions['anger']\n",
+        "neg += emotions['disgust']\n",
+        "neg += emotions['positive']\n",
+        "\n",
+        "total = pos + neg\n",
+        "ratio = abs(pos - neg) / total if total else 0\n",
+        "\n",
+        "if ratio < .75:\n",
+        "  print('neutral')\n",
+        "elif pos > neg:\n",
+        "  print('positive')\n",
+        "else:\n",
+        "  print('negative')"
+      ],
+      "metadata": {
+        "id": "FzXDtgrzOLWp"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#There you go!"
+      ],
+      "metadata": {
+        "id": "0DrxsX0WPmct"
+      }
+    }
+  ]
+}

--- a/nrclex.py
+++ b/nrclex.py
@@ -4,11 +4,104 @@
 """
 
 # Determine word affect based on the NRC emotional lexicon
-# Library is built on TextBlob
 
-from textblob import TextBlob
+
+from nltk.corpus import wordnet
+from nltk.tokenize import TweetTokenizer, PunktSentenceTokenizer
+from nltk.stem import WordNetLemmatizer
 from collections import Counter
-from json import load
+import csv
+
+
+def load(txt_file, colname = None):
+    reader = csv.reader(txt_file, delimiter='\t')
+    firstrow = next(reader)
+    emotions = [
+        'anger', 'anticipation', 'disgust', 'fear',
+        'joy', 'negative', 'positive', 'sadness',
+        'surprise', 'trust'
+        ]
+    lex = {}
+
+    try:
+        head = {
+            **{x: firstrow.index(x) for x in emotions},
+            **{x: firstrow.index(x) for x in firstrow if x not in emotions}
+            }
+    except ValueError:
+        head = None
+
+    if head:
+        col = head[colname] if colname else head[firstrow[-1]]
+
+        for row in reader:
+            values = [x for x in emotions if row[head[x]] == '1']
+
+            if values:
+                lex[row[col]] = values
+    else:
+        if firstrow[2] == '1':
+            lex[firstrow[0]] = [firstrow[1]]
+
+        for row in reader:
+            if row[2] == '1':
+                if row[0] not in lex:
+                    lex[row[0]] = []
+
+                lex[row[0]].append(row[1])
+
+    return lex
+
+
+def __expand_lexicon__(self):
+    vectors = []
+    n_words = len(self.words)
+
+    for i in range(n_words):
+        if i + 2 < n_words:
+            vectors.append(
+                f'{self.words[i]} {self.words[i+1]} {self.words[i+2]}')
+        if i + 1 < n_words:
+            vectors.append(f'{self.words[i]} {self.words[i+1]}')
+        if i < n_words:
+            vectors.append(self.words[i])
+
+    for i in set(vectors):
+        if i in self.__lexicon__:
+            continue
+
+        found = False
+        splits = i.split()
+        use_antonyms = False
+
+        if len(splits) > 1 and (splits[0] == 'not' or "n't" in splits[0]):
+            use_antonyms = True
+            context = '_'.join(splits[1:])
+        else:
+            context = i.replace(' ', '_')
+
+        for j in wordnet.synsets(context):
+            for k in set(j.lemmas()):
+                meaning = None
+
+                if use_antonyms:
+                    antonyms = k.antonyms()
+
+                    if antonyms:
+                        meaning = antonyms[0].name().replace('_', ' ')
+                else:
+                    meaning = k.name().replace('_', ' ')
+
+                if meaning in self.__lexicon__:
+                    self.__lexicon__[i] = self.__lexicon__[meaning]
+                    found = True
+                    break
+
+            if found:
+                break
+
+        if found:
+            continue
 
 
 def __build_word_affect__(self):
@@ -23,12 +116,12 @@ def __build_word_affect__(self):
     affect_dict = dict()
     affect_frequencies = Counter()
     lexicon_keys = self.__lexicon__.keys()
-    for word in self.words:
-        if word in lexicon_keys:
-            affect_list.extend(self.__lexicon__[word])
-            affect_dict.update({word: self.__lexicon__[word]})
-    for word in affect_list:
-        affect_frequencies[word] += 1
+    for phrase in self.words_and_phrases:
+        if phrase in lexicon_keys:
+            affect_list.extend(self.__lexicon__[phrase])
+            affect_dict.update({phrase: self.__lexicon__[phrase]})
+    for phrase in affect_list:
+        affect_frequencies[phrase] += 1
     sum_values = sum(affect_frequencies.values())
     affect_percent = {'fear': 0.0, 'anger': 0.0, 'anticipation': 0.0, 'trust': 0.0, 'surprise': 0.0, 'positive': 0.0,
                       'negative': 0.0, 'sadness': 0.0, 'disgust': 0.0, 'joy': 0.0}
@@ -38,6 +131,31 @@ def __build_word_affect__(self):
     self.affect_dict = affect_dict
     self.raw_emotion_scores = dict(affect_frequencies)
     self.affect_frequencies = affect_percent
+
+
+def words_and_phrases(self):
+    words_and_phrases = []
+    n_words = len(self.words)
+    i = 0
+
+    while i < n_words:
+        if i + 2 < n_words:
+            phrase = f'{self.words[i]} {self.words[i+1]} {self.words[i+2]}'
+
+            if phrase in self.__lexicon__:
+                words_and_phrases.append(phrase)
+                i += 3
+        if i + 1 < n_words:
+            phrase = f'{self.words[i]} {self.words[i+1]}'
+
+            if phrase in self.__lexicon__:
+                words_and_phrases.append(phrase)
+                i += 2
+        if i < n_words:
+            words_and_phrases.append(self.words[i])
+            i += 1
+
+    self.words_and_phrases = words_and_phrases
 
 
 def top_emotions(self):
@@ -56,9 +174,10 @@ def top_emotions(self):
 class NRCLex:
     """Lexicon source is (C) 2016 National Research Council Canada (NRC) and library is for research purposes only.  Source: http://sentiment.nrc.ca/lexicons-for-research/"""
 
-    def __init__(self, lexicon_file='nrc_en.json'):
-        with open(lexicon_file, 'r') as json_file:
-            self.__lexicon__ = load(json_file)
+    def __init__(self, lex_filename, colname = None):
+        with open(lex_filename, 'r') as txt_file:
+            self.__lexicon__ = load(txt_file, colname)
+
 
     def load_token_list(self, token_list):
         '''
@@ -68,26 +187,40 @@ class NRCLex:
         Parameters:
             token_list (list): a list of utf-8 strings.
         Returns:
-            No return
+            self
         '''
         self.text = ""
         self.words = token_list
+        self.words_and_phrases = token_list
         self.sentences = []
+        __expand_lexicon__(self)
         __build_word_affect__(self)
         top_emotions(self)
 
+        return self
+
+
     def load_raw_text(self, text):
         '''
-        Load a string into the NRCLex object for tokenization and lemmatization with TextBlob.
+        Load a string into the NRCLex object for tokenization
 
         Parameters:
             text (str): a utf-8 string.
         Returns:
-            No return
+            self
         '''
+
+        wln = WordNetLemmatizer()
+        tt = TweetTokenizer()
+        pst = PunktSentenceTokenizer()
+
         self.text = text
-        blob = TextBlob(self.text)
-        self.words = [w.lemmatize() for w in blob.words]
-        self.sentences = list(blob.sentences)
+        self.words = [wln.lemmatize(x, 'v') for x in tt.tokenize(text)]
+        self.sentences = pst.tokenize(text)
+
+        __expand_lexicon__(self)
+        words_and_phrases(self)
         __build_word_affect__(self)
         top_emotions(self)
+
+        return self

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/metalcorebear/NRCLex",
     packages=setuptools.find_packages(),
-    install_requires=['textblob', 'collections', 'json'],
-    include_package_data=True,
+    install_requires=['nltk'],
+    include_package_data=False,
     package_data={'': ['nrc_en.json']},
     py_modules=["nrclex"],
     classifiers=[


### PR DESCRIPTION
# What's new:
- Read from an NRC lexicon txt, any formats, any languages
- Word by word lemmatization isn't enough, we need to expand the loaded lexicon instead
- Less dependencies
- Add [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/metalcorebear/NRCLex/example.ipynb) badge
- Negation support. Fix #4 

# Example
### Text: `she's always arguing!`

**New:**
```
{'fear': 0.0,
 'anger': 0.3333333333333333,
 'anticipation': 0.0,
 'trust': 0.3333333333333333,
 'surprise': 0.0,
 'positive': 0.0,
 'negative': 0.3333333333333333,
 'sadness': 0.0,
 'disgust': 0.0,
 'joy': 0.0}
```
**Previous:**
```
{'fear': 0.0,
 'anger': 0.0,
 'anticip': 0.0,
 'trust': 0.0,
 'surprise': 0.0,
 'positive': 0.0,
 'negative': 0.0,
 'sadness': 0.0,
 'disgust': 0.0,
 'joy': 0.0}
```

### To see all of the possible expansions
```
# use the old version

def expand_synonyms(lex):
    from nltk.corpus import wordnet

    lex_ = {}

    for i in lex:
        for j in wordnet.synsets(i):
            for k in j.lemmas():
                word = k.name().replace('_', ' ')

                if not word in lex:
                    lex_[word] = lex[i]

    return lex_

expand_synonyms(nrc.lexicon)
```